### PR TITLE
Have getPath() return the correct info in JAX-RS

### DIFF
--- a/src/main/java/org/pac4j/jax/rs/filter/JaxRsContext.java
+++ b/src/main/java/org/pac4j/jax/rs/filter/JaxRsContext.java
@@ -70,4 +70,20 @@ public class JaxRsContext extends J2EContext {
                 cookie.isSecure(), cookie.isHttpOnly()));
     }
 
+    /**
+     * When using JAX-RS over a Servlet container, the path info is what we are interested in.
+     * 
+     * The context path is the base path of the servlet context that contains the servlet for the JAX-RS implementation.
+     * 
+     * The servlet path is the base path of the servlet itself.
+     * 
+     * And the path info is what is left after that.
+     * 
+     * Since we are working only with URIs inside the JAX-RS implementation, we only need the path info!
+     */
+    @Override
+    public String getPath() {
+        return getRequest().getPathInfo();
+    }
+
 }


### PR DESCRIPTION
In the context of a JAX-RS implementation in a Servlet container,
the implementation was incorrect because the servlet path itself
shouldn't be included in the URI.

getPathInfo() gives us the correct information in that context.

@leleuj, here is a PR for you to review because it is related to pac4j/pac4j#63 that we fixed together in the past.

I realised that in most of the pac4j j2e examples, the servlet path is part of the URL to match (e.g., `/facebook/....`), while with Jersey, the servlet path should NOT be included in the URL to match (if Jersey is deployed on say a servlet with path mapping `/api/`, then this should not be part of the URL to match since all the URLs in Jersey are defined relative to `/api/` (and relative to the context path, which is before the servlet path ^^).
I think this may be of interest to you since the problem will maybe reappear in the future for other integrations…