### PR TITLE
Populate the SecurityManager with id and roles

### DIFF
--- a/src/main/java/org/pac4j/jax/rs/filters/ApplicationLogoutFilter.java
+++ b/src/main/java/org/pac4j/jax/rs/filters/ApplicationLogoutFilter.java
@@ -9,6 +9,7 @@ import org.pac4j.core.engine.ApplicationLogoutLogic;
 import org.pac4j.core.engine.DefaultApplicationLogoutLogic;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.jax.rs.pac4j.JaxRsContext;
+import org.pac4j.jax.rs.pac4j.JaxRsProfileManager;
 
 /**
  * 
@@ -26,6 +27,8 @@ public class ApplicationLogoutFilter extends AbstractFilter {
 
     public ApplicationLogoutFilter(Providers providers, Config config) {
         super(providers, config);
+        ((DefaultApplicationLogoutLogic<Object, JaxRsContext>) applicationLogoutLogic)
+                .setProfileManagerFactory(c -> new JaxRsProfileManager(c));
     }
 
     @Override

--- a/src/main/java/org/pac4j/jax/rs/filters/CallbackFilter.java
+++ b/src/main/java/org/pac4j/jax/rs/filters/CallbackFilter.java
@@ -8,6 +8,7 @@ import org.pac4j.core.config.Config;
 import org.pac4j.core.engine.CallbackLogic;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.jax.rs.pac4j.JaxRsContext;
+import org.pac4j.jax.rs.pac4j.JaxRsProfileManager;
 import org.pac4j.jax.rs.pac4j.JaxRsRenewSessionCallbackLogic;
 
 /**
@@ -28,6 +29,8 @@ public class CallbackFilter extends AbstractFilter {
 
     public CallbackFilter(Providers providers, Config config) {
         super(providers, config);
+        ((JaxRsRenewSessionCallbackLogic<JaxRsContext>) callbackLogic)
+                .setProfileManagerFactory(c -> new JaxRsProfileManager(c));
     }
 
     @Override

--- a/src/main/java/org/pac4j/jax/rs/filters/SecurityFilter.java
+++ b/src/main/java/org/pac4j/jax/rs/filters/SecurityFilter.java
@@ -10,6 +10,7 @@ import org.pac4j.core.engine.SecurityGrantedAccessAdapter;
 import org.pac4j.core.engine.SecurityLogic;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.jax.rs.pac4j.JaxRsContext;
+import org.pac4j.jax.rs.pac4j.JaxRsProfileManager;
 
 /**
  * 
@@ -34,6 +35,8 @@ public class SecurityFilter extends AbstractFilter {
 
     public SecurityFilter(Providers providers, Config config) {
         super(providers, config);
+        ((DefaultSecurityLogic<Object, JaxRsContext>) securityLogic)
+                .setProfileManagerFactory(c -> new JaxRsProfileManager(c));
     }
 
     @Override

--- a/src/main/java/org/pac4j/jax/rs/pac4j/JaxRsProfileManager.java
+++ b/src/main/java/org/pac4j/jax/rs/pac4j/JaxRsProfileManager.java
@@ -1,0 +1,166 @@
+package org.pac4j.jax.rs.pac4j;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.SecurityContext;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileHelper;
+import org.pac4j.core.profile.ProfileManager;
+import org.pac4j.core.util.CommonHelper;
+
+/**
+ * 
+ * @author Victor Noel - Linagora
+ * @since 1.0.0
+ *
+ */
+public class JaxRsProfileManager extends ProfileManager<CommonProfile> {
+
+    public JaxRsProfileManager(WebContext context) {
+        super(context);
+
+        ContainerRequestContext requestContext = getJaxRsContext().getRequestContext();
+        SecurityContext original = requestContext.getSecurityContext();
+        if (!(original instanceof Pac4JSecurityContext)) {
+            requestContext.setSecurityContext(new Pac4JSecurityContext(original));
+        }
+    }
+
+    protected JaxRsContext getJaxRsContext() {
+        return (JaxRsContext) this.context;
+    }
+
+    @Override
+    protected LinkedHashMap<String, CommonProfile> retrieveAll(boolean readFromSession) {
+        LinkedHashMap<String, CommonProfile> profiles = super.retrieveAll(readFromSession);
+
+        SecurityContext securityContext = getJaxRsContext().getRequestContext().getSecurityContext();
+        if (securityContext instanceof Pac4JSecurityContext) {
+            ((Pac4JSecurityContext) securityContext).setPrincipal(profiles);
+        }
+
+        return profiles;
+    }
+
+    @Override
+    public void logout() {
+        super.logout();
+
+        SecurityContext securityContext = getJaxRsContext().getRequestContext().getSecurityContext();
+        if (securityContext instanceof Pac4JSecurityContext) {
+            ((Pac4JSecurityContext) securityContext).unsetPrincipal();
+        }
+    }
+
+    private static class Pac4JSecurityContext implements SecurityContext {
+
+        private final SecurityContext original;
+
+        private PrincipalImpl principal;
+
+        public Pac4JSecurityContext(SecurityContext original) {
+            this.original = original;
+        }
+
+        public void setPrincipal(LinkedHashMap<String, CommonProfile> profiles) {
+            if (profiles != null && !profiles.isEmpty()) {
+                principal = new PrincipalImpl(profiles);
+            }
+        }
+
+        public void unsetPrincipal() {
+            this.principal = null;
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            if (principal != null) {
+                return principal;
+            } else {
+                return original != null ? original.getUserPrincipal() : null;
+            }
+        }
+
+        @Override
+        public boolean isUserInRole(String role) {
+            if (principal != null) {
+                return principal.getRoles().contains(role);
+            } else {
+                return original != null && original.isUserInRole(role);
+            }
+        }
+
+        @Override
+        public boolean isSecure() {
+            return original != null && original.isSecure();
+        }
+
+        @Override
+        public String getAuthenticationScheme() {
+            if (principal != null) {
+                return "PAC4J";
+            } else {
+                return original != null ? original.getAuthenticationScheme() : null;
+            }
+        }
+    }
+
+    public static class PrincipalImpl implements Principal {
+
+        private final CommonProfile profile;
+
+        private final Set<String> roles;
+
+        public PrincipalImpl(LinkedHashMap<String, CommonProfile> profiles) {
+            Optional<CommonProfile> optProfile = ProfileHelper.flatIntoOneProfile(profiles);
+            if (!optProfile.isPresent()) {
+                throw new IllegalArgumentException();
+            }
+            this.profile = optProfile.get();
+            Set<String> rs = new HashSet<>();
+            profiles.values().stream().forEach(p -> rs.addAll(p.getRoles()));
+            this.roles = Collections.unmodifiableSet(rs);
+        }
+
+        @Override
+        public String getName() {
+            return this.profile.getId();
+        }
+
+        public Set<String> getRoles() {
+            return roles;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getName());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final PrincipalImpl principal = (PrincipalImpl) o;
+            return CommonHelper.areEquals(this.getName(), principal.getName());
+        }
+
+        @Override
+        public String toString() {
+            return CommonHelper.toString(this.getClass(), "profile", this.profile);
+        }
+    }
+}


### PR DESCRIPTION
For #7 

As I said in the issue, I'm not totally happy with it, but it is as good as what is done for undertow and also covers logout.

> The interplay of profile in session or not is not easy to deal with... I think there may be corner cases where there would be a profile stored in session and one not stored in session (in case of multiprofile) and depending on the order of the clients of the filter, then the SecurityContext would be different (because it would be loaded based on the parameter readFromSession itself based on the clients used for authentication...).
> 
> Another solution would be to incrementally populate the SecurityContext based on calls to save and to retrieveAll... still I'm not so happy with the way the ProfileManager works :)
