### PR TITLE
Set the headers and co on the normal response

### DIFF
--- a/src/main/java/org/pac4j/jax/rs/filters/AbstractFilter.java
+++ b/src/main/java/org/pac4j/jax/rs/filters/AbstractFilter.java
@@ -4,8 +4,11 @@ import java.io.IOException;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Providers;
 
+import org.pac4j.core.authorization.authorizer.Authorizer;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.http.HttpActionAdapter;
 import org.pac4j.jax.rs.features.JaxRsContextFactoryProvider.JaxRsContextFactory;
@@ -18,7 +21,7 @@ import org.pac4j.jax.rs.pac4j.JaxRsContext;
  * @since 1.0.0
  *
  */
-public abstract class AbstractFilter implements ContainerRequestFilter {
+public abstract class AbstractFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
     protected Boolean skipResponse;
 
@@ -27,7 +30,7 @@ public abstract class AbstractFilter implements ContainerRequestFilter {
     public AbstractFilter(Providers providers) {
         this.providers = providers;
     }
-    
+
     protected Config getConfig() {
         return ProvidersHelper.getContext(providers, Config.class);
     }
@@ -41,6 +44,22 @@ public abstract class AbstractFilter implements ContainerRequestFilter {
         assert context != null;
 
         filter(context);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        // in case the filter aborts the request, we never arrive here, but if it is not aborted
+        // there is case when pac4j sets things on the response, this is the role of this method.
+        // unfortunately, if skipResponse is used, we can't do that because pac4j considers
+        // its abort response in the same way as the normal response
+        if (skipResponse == null || !skipResponse) {
+            JaxRsContext context = ProvidersHelper.getContext(providers, JaxRsContextFactory.class)
+                    .provides(requestContext);
+            assert context != null;
+
+            context.getResponseHolder().populateResponse(responseContext);
+        }
     }
 
     /**
@@ -70,6 +89,9 @@ public abstract class AbstractFilter implements ContainerRequestFilter {
     }
 
     /**
+     * Note that if this is set to <code>true</code>, this will also disable the effects of {@link Authorizer} and such
+     * that set things on the HTTP response! Use with caution!
+     * 
      * @param skipResponse
      *            If set to <code>true</code>, the pac4j response, such as redirect, will be skipped (the annotated
      *            method will be executed instead).

--- a/src/main/java/org/pac4j/jax/rs/filters/JaxRsHttpActionAdapter.java
+++ b/src/main/java/org/pac4j/jax/rs/filters/JaxRsHttpActionAdapter.java
@@ -1,5 +1,7 @@
 package org.pac4j.jax.rs.filters;
 
+import javax.ws.rs.core.Response;
+
 import org.pac4j.core.http.HttpActionAdapter;
 import org.pac4j.jax.rs.pac4j.JaxRsContext;
 
@@ -15,7 +17,9 @@ public class JaxRsHttpActionAdapter implements HttpActionAdapter<Object, JaxRsCo
 
     @Override
     public Object adapt(int code, JaxRsContext context) {
-        context.getRequestContext().abortWith(context.getAbortBuilder().build());
+        Response response = context.getAbortBuilder().build();
+        assert response.getStatus() == code;
+        context.getRequestContext().abortWith(response);
         return null;
     }
 

--- a/src/test/java/org/pac4j/jax/rs/AbstractTest.java
+++ b/src/test/java/org/pac4j/jax/rs/AbstractTest.java
@@ -6,6 +6,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -184,5 +185,17 @@ public abstract class AbstractTest {
         final String ok = container.getTarget("/directInjectSkip").request()
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE), String.class);
         assertThat(ok).isEqualTo("fail");
+    }
+
+    @Test
+    public void directResponseHeadersSet() {
+        Form form = new Form();
+        form.param("username", "foo");
+        form.param("password", "foo");
+        final Response ok = container.getTarget("/directResponseHeadersSet").request()
+                .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+        assertThat(ok.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(ok.readEntity(String.class)).isEqualTo("ok");
+        assertThat(ok.getHeaderString("X-Content-Type-Options")).isEqualTo("nosniff");
     }
 }

--- a/src/test/java/org/pac4j/jax/rs/resources/TestResource.java
+++ b/src/test/java/org/pac4j/jax/rs/resources/TestResource.java
@@ -95,4 +95,12 @@ public class TestResource {
             return "fail";
         }
     }
+
+    @POST
+    @Path("directResponseHeadersSet")
+    @Pac4JSecurity(clients = "DirectFormClient", authorizers = { DefaultAuthorizers.IS_AUTHENTICATED,
+            DefaultAuthorizers.NOSNIFF })
+    public String directResponseHeadersSet() {
+        return "ok";
+    }
 }


### PR DESCRIPTION
All the properties set by pac4j (e.g., headers from authorizers) were
only set on the response in case of failure, but not when the jax-rs
runtime was answering.

This is fixed, but the `skipResponse` option disables this behaviour.

Closes pac4j/dropwizard-pac4j#34