### PR TITLE
JaxRsUrlResolver must retain original unresolved URL when no appropriate WebContext is provided

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,5 +38,29 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+	<dependency>
+	  <groupId>junit</groupId>
+	  <artifactId>junit</artifactId>
+	  <version>4.12</version>
+	  <scope>test</scope>
+	  <exclusions>
+	    <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+	</dependency>
+	<dependency>
+	    <groupId>org.hamcrest</groupId>
+	    <artifactId>hamcrest-core</artifactId>
+	    <version>2.2</version>
+	    <scope>test</scope>
+	</dependency>
+	<dependency>
+	    <groupId>org.mockito</groupId>
+	    <artifactId>mockito-core</artifactId>
+	    <version>3.1.0</version>
+	    <scope>test</scope>
+	</dependency>
   </dependencies>
 </project>

--- a/core/src/main/java/org/pac4j/jax/rs/pac4j/JaxRsUrlResolver.java
+++ b/core/src/main/java/org/pac4j/jax/rs/pac4j/JaxRsUrlResolver.java
@@ -19,7 +19,7 @@ public class JaxRsUrlResolver implements UrlResolver {
         if (context instanceof JaxRsContext && url != null) {
             return ((JaxRsContext) context).getAbsolutePath(url, true);
         }
-        return null;
+        return url;
     }
 
 }

--- a/core/src/test/java/org/pac4j/jax/rs/pac4j/JaxRsUrlResolverTest.java
+++ b/core/src/test/java/org/pac4j/jax/rs/pac4j/JaxRsUrlResolverTest.java
@@ -1,0 +1,56 @@
+package org.pac4j.jax.rs.pac4j;
+
+import static org.mockito.Mockito.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+import org.pac4j.core.context.WebContext;
+
+public class JaxRsUrlResolverTest {
+
+    @Test
+    public void null_url_with_non_jaxrs_context_resolves_as_null() {
+        WebContext context = mock(WebContext.class);
+        
+        JaxRsUrlResolver resolver = new JaxRsUrlResolver();
+        String resolvedUrl = resolver.compute(null, context);
+        assertThat(resolvedUrl, is(nullValue()));
+    }
+
+    @Test
+    public void null_url_with_jaxrs_context_resolves_as_null() {
+        JaxRsContext context = mock(JaxRsContext.class);
+        
+        JaxRsUrlResolver resolver = new JaxRsUrlResolver();
+        String resolvedUrl = resolver.compute(null, context);
+        assertThat(resolvedUrl, is(nullValue()));
+    }
+
+    @Test
+    public void relative_url_with_non_jaxrs_context_is_left_unresolved() {
+        WebContext context = mock(WebContext.class);
+        
+        JaxRsUrlResolver resolver = new JaxRsUrlResolver();
+        String resolvedUrl = resolver.compute("/a/relative/url", context);
+        assertThat(resolvedUrl, is("/a/relative/url"));
+    }
+
+    @Test
+    public void relative_url_with_jaxrs_context_is_resolved_as_absolute_url() {
+        JaxRsContext context = mock(JaxRsContext.class);
+        when(context.getAbsolutePath(anyString(), eq(true))).thenAnswer(invocation -> { return "http://domain/app"+invocation.getArgument(0); });
+        
+        JaxRsUrlResolver resolver = new JaxRsUrlResolver();
+        String resolvedUrl = resolver.compute("/a/relative/url", context);
+        assertThat(resolvedUrl, is("http://domain/app/a/relative/url"));
+    }
+
+    @Test
+    public void relative_url_with_null_context_is_left_unresolved() {
+        JaxRsUrlResolver resolver = new JaxRsUrlResolver();
+        String resolvedUrl = resolver.compute("/a/relative/url", null);
+        assertThat(resolvedUrl, is("/a/relative/url"));
+    }
+}


### PR DESCRIPTION
The URL resolution process in class `JaxRsUrlResolver` involves a `WebContext` so that any relative URI can be properly resolved into an absolute URI.

When the `WebContext` is `null` or not the expected implementation, then the current implementation returns `null`.

It must return the original unresolved URI instead, to match the behaviour of `org.pac4j.core.http.url.DefaultUrlResolver` in `pac4j-core`.

This is especially useful because it allows using indirect clients with a relative redirect URI which can then be resolved at request-time rather than hardcoded / configured upfront.

This patch provides this change, and also adds unit tests for this class (were not existing before).