### PR TITLE
Added SessionStore to Pac4JSecurityContext

### DIFF
--- a/core/src/main/java/org/pac4j/jax/rs/filters/SecurityFilter.java
+++ b/core/src/main/java/org/pac4j/jax/rs/filters/SecurityFilter.java
@@ -119,7 +119,7 @@ public class SecurityFilter extends AbstractFilter {
                 JaxRsContext jaxRsContext = (JaxRsContext) context;
                 SecurityContext original = jaxRsContext.getRequestContext().getSecurityContext();
                 jaxRsContext.getRequestContext()
-                        .setSecurityContext(new Pac4JSecurityContext(original, jaxRsContext, profiles));
+                        .setSecurityContext(new Pac4JSecurityContext(original, jaxRsContext, sessionStore, profiles));
             }
             return null;
         }

--- a/core/src/main/java/org/pac4j/jax/rs/pac4j/JaxRsProfileManager.java
+++ b/core/src/main/java/org/pac4j/jax/rs/pac4j/JaxRsProfileManager.java
@@ -39,10 +39,14 @@ public class JaxRsProfileManager extends ProfileManager {
 
         private final JaxRsContext context;
 
-        public Pac4JSecurityContext(SecurityContext original, JaxRsContext context, Collection<UserProfile> profiles) {
+        private final SessionStore sessionStore;
+
+        public Pac4JSecurityContext(SecurityContext original, JaxRsContext context, SessionStore sessionStore,
+                Collection<UserProfile> profiles) {
             this.original = original;
             this.context = context;
             this.profiles = profiles;
+            this.sessionStore = sessionStore;
             this.principal = ProfileHelper.flatIntoOneProfile(profiles).map(Pac4JPrincipal::new).orElse(null);
         }
 
@@ -59,6 +63,10 @@ public class JaxRsProfileManager extends ProfileManager {
         public JaxRsContext getContext() {
             // even after logout we can access the context
             return this.context;
+        }
+
+        public SessionStore getSessionStore() {
+            return sessionStore;
         }
 
         @Override

--- a/jersey/src/test/java/org/pac4j/jax/rs/resources/JerseyResource.java
+++ b/jersey/src/test/java/org/pac4j/jax/rs/resources/JerseyResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Providers;
 
 import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
+import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.jax.rs.annotations.Pac4JSecurity;
 import org.pac4j.jax.rs.features.JaxRsContextFactoryProvider.JaxRsContextFactory;
 import org.pac4j.jax.rs.helpers.ProvidersContext;
@@ -48,6 +49,18 @@ public class JerseyResource {
         JaxRsContext context = new ProvidersContext(providers).resolveNotNull(JaxRsContextFactory.class)
                 .provides(requestContext);
         if (context != null) {
+            return "ok";
+        } else {
+            return "fail";
+        }
+    }
+
+    @POST
+    @Path("/sessionstore")
+    @Pac4JSecurity(clients = "DirectFormClient", authorizers = DefaultAuthorizers.IS_AUTHENTICATED)
+    public String directSessionStore() {
+        SessionStore sessionStore = new ProvidersContext(providers).resolveNotNull(SessionStore.class);
+        if (sessionStore != null) {
             return "ok";
         } else {
             return "fail";

--- a/jersey225/src/test/java/org/pac4j/jax/rs/resources/JerseyResource.java
+++ b/jersey225/src/test/java/org/pac4j/jax/rs/resources/JerseyResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Providers;
 
 import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
+import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.jax.rs.annotations.Pac4JSecurity;
 import org.pac4j.jax.rs.features.JaxRsContextFactoryProvider.JaxRsContextFactory;
 import org.pac4j.jax.rs.helpers.ProvidersContext;
@@ -48,6 +49,18 @@ public class JerseyResource {
         JaxRsContext context = new ProvidersContext(providers).resolveNotNull(JaxRsContextFactory.class)
                 .provides(requestContext);
         if (context != null) {
+            return "ok";
+        } else {
+            return "fail";
+        }
+    }
+
+    @POST
+    @Path("/sessionstore")
+    @Pac4JSecurity(clients = "DirectFormClient", authorizers = DefaultAuthorizers.IS_AUTHENTICATED)
+    public String directSessionStore() {
+        SessionStore sessionStore = new ProvidersContext(providers).resolveNotNull(SessionStore.class);
+        if (sessionStore != null) {
             return "ok";
         } else {
             return "fail";

--- a/jersey228/src/test/java/org/pac4j/jax/rs/resources/JerseyResource.java
+++ b/jersey228/src/test/java/org/pac4j/jax/rs/resources/JerseyResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Providers;
 
 import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
+import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.jax.rs.annotations.Pac4JSecurity;
 import org.pac4j.jax.rs.features.JaxRsContextFactoryProvider.JaxRsContextFactory;
 import org.pac4j.jax.rs.helpers.ProvidersContext;
@@ -48,6 +49,18 @@ public class JerseyResource {
         JaxRsContext context = new ProvidersContext(providers).resolveNotNull(JaxRsContextFactory.class)
                 .provides(requestContext);
         if (context != null) {
+            return "ok";
+        } else {
+            return "fail";
+        }
+    }
+
+    @POST
+    @Path("/sessionstore")
+    @Pac4JSecurity(clients = "DirectFormClient", authorizers = DefaultAuthorizers.IS_AUTHENTICATED)
+    public String directSessionStore() {
+        SessionStore sessionStore = new ProvidersContext(providers).resolveNotNull(SessionStore.class);
+        if (sessionStore != null) {
             return "ok";
         } else {
             return "fail";

--- a/resteasy/src/test/java/org/pac4j/jax/rs/resources/RestEasyResource.java
+++ b/resteasy/src/test/java/org/pac4j/jax/rs/resources/RestEasyResource.java
@@ -6,6 +6,7 @@ import javax.ws.rs.core.SecurityContext;
 
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
+import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.jax.rs.annotations.Pac4JSecurity;
 import org.pac4j.jax.rs.pac4j.JaxRsContext;
 import org.pac4j.jax.rs.pac4j.JaxRsProfileManager.Pac4JSecurityContext;
@@ -36,8 +37,25 @@ public class RestEasyResource {
     public String directContext() {
         SecurityContext scontext = ResteasyProviderFactory.getContextData(SecurityContext.class);
         if (scontext != null && scontext instanceof Pac4JSecurityContext) {
-            JaxRsContext context = ((Pac4JSecurityContext)scontext).getContext();
+            JaxRsContext context = ((Pac4JSecurityContext) scontext).getContext();
             if (context != null) {
+                return "ok";
+            } else {
+                return "fail";
+            }
+        } else {
+            return "error";
+        }
+    }
+
+    @POST
+    @Path("/sessionstore")
+    @Pac4JSecurity(clients = "DirectFormClient", authorizers = DefaultAuthorizers.IS_AUTHENTICATED)
+    public String directSessionStore() {
+        SecurityContext scontext = ResteasyProviderFactory.getContextData(SecurityContext.class);
+        if (scontext != null && scontext instanceof Pac4JSecurityContext) {
+            SessionStore sessionStore = ((Pac4JSecurityContext) scontext).getSessionStore();
+            if (sessionStore != null) {
                 return "ok";
             } else {
                 return "fail";

--- a/testing/src/main/java/org/pac4j/jax/rs/AbstractTest.java
+++ b/testing/src/main/java/org/pac4j/jax/rs/AbstractTest.java
@@ -228,4 +228,14 @@ public abstract class AbstractTest {
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE), String.class);
         assertThat(ok).isEqualTo("ok");
     }
+
+    @Test
+    public void containerSpecificSessionStore() {
+        Form form = new Form();
+        form.param("username", "foo");
+        form.param("password", "foo");
+        final String ok = container.getTarget("/containerSpecific/sessionstore").request()
+                .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE), String.class);
+        assertThat(ok).isEqualTo("ok");
+    }
 }


### PR DESCRIPTION
An last addition for version 5 to access the SessionStore via the SecurityContext (not the Pac4JContext). This is an fallback if the injection of the parameters is not used (see [current Wiki](https://github.com/pac4j/jax-rs-pac4j/wiki/Get-the-authenticated-user-profiles#without-method-parameters-injection)). Furthermore i also updated the Wiki ([Preview](https://github.com/SiMiKohl/jax-rs-pac4j/wiki), [Zipped patch](https://github.com/pac4j/jax-rs-pac4j/files/8233672/0001-Changes-for-version-5.zip)).

 