### PR TITLE
Pass `createSession` to native `getSession` call

### DIFF
--- a/core/src/main/java/org/pac4j/jax/rs/servlet/pac4j/ServletSessionStore.java
+++ b/core/src/main/java/org/pac4j/jax/rs/servlet/pac4j/ServletSessionStore.java
@@ -20,77 +20,79 @@ public class ServletSessionStore implements SessionStore {
 
     public static final ServletSessionStore INSTANCE = new ServletSessionStore();
 
-    protected HttpSession httpSession;
+    protected ServletSessionStore() {}
 
-    protected ServletSessionStore() {
-    }
-
-    protected ServletSessionStore(final HttpSession httpSession) {
-        this.httpSession = httpSession;
-    }
-
-    public HttpSession getHttpSession(WebContext context) {
+    public Optional<HttpSession> getNativeSession(final WebContext context, final boolean createSession) {
         assert context instanceof ServletJaxRsContext;
-        return ((ServletJaxRsContext) context).getRequest().getSession();
+
+        final HttpSession nativeSession = ((ServletJaxRsContext) context).getRequest().getSession(createSession);
+        return Optional.ofNullable(nativeSession);
     }
 
     @Override
-    public Optional<Object> get(WebContext context, String key) {
-        return Optional.ofNullable(getHttpSession(context).getAttribute(key));
+    public Optional<Object> get(final WebContext context, final String key) {
+        return getNativeSession(context, false)
+            .map(it -> it.getAttribute(key));
     }
 
     @Override
-    public void set(WebContext context, String key, Object value) {
-        if (value == null) {
-            getHttpSession(context).removeAttribute(key);
-        } else {
-            getHttpSession(context).setAttribute(key, value);
-        }
+    public void set(final WebContext context, final String key, final Object value) {
+        getNativeSession(context, value != null)
+            .ifPresent(it -> {
+                if (value == null) {
+                    it.removeAttribute(key);
+                } else {
+                    it.setAttribute(key, value);
+                }
+            });
     }
 
     @Override
-    public boolean destroySession(WebContext context) {
-        final HttpSession session = getHttpSession(context);
-
-        session.invalidate();
-
-        return true;
+    public boolean destroySession(final WebContext context) {
+        return getNativeSession(context, false)
+            .map(it -> {
+                it.invalidate();
+                return true;
+            })
+            .orElse(false);
     }
 
     @Override
-    public Optional<Object> getTrackableSession(WebContext context) {
-        return Optional.ofNullable(getHttpSession(context));
+    public Optional<Object> getTrackableSession(final WebContext context) {
+        return Optional.ofNullable(getNativeSession(context, false));
     }
 
     @Override
-    public boolean renewSession(WebContext context) {
-        final HttpSession session = getHttpSession(context);
-        final Map<String, Object> attributes = new HashMap<>();
-        Collections.list(session.getAttributeNames()).forEach(k -> attributes.put(k, session.getAttribute(k)));
+    public boolean renewSession(final WebContext context) {
+        return getNativeSession(context, false)
+            .map(it -> {
+                final Map<String, Object> attributes = new HashMap<>();
+                Collections.list(it.getAttributeNames()).forEach(k -> attributes.put(k, it.getAttribute(k)));
 
-        session.invalidate();
+                it.invalidate();
 
-        // let's recreate the session from zero, the previous becomes
-        // generally unusable depending on the servlet implementation
-        final HttpSession newSession = getHttpSession(context);
-        attributes.forEach(newSession::setAttribute);
+                // let's recreate the session from zero, the previous becomes
+                // generally unusable depending on the servlet implementation
+                getNativeSession(context, true)
+                    .ifPresent(newSession -> attributes.forEach(newSession::setAttribute));
 
-        return true;
+                return true;
+            })
+            .orElse(false);
     }
 
     @Override
-    public Optional<SessionStore> buildFromTrackableSession(WebContext context, Object trackableSession) {
-        return Optional.ofNullable(new ServletSessionStore() {
+    public Optional<SessionStore> buildFromTrackableSession(final WebContext context, final Object trackableSession) {
+        return Optional.of(new ServletSessionStore() {
             @Override
-            public HttpSession getHttpSession(WebContext context) {
-                return (HttpSession) trackableSession;
+            public Optional<HttpSession> getNativeSession(WebContext context, boolean createSession) {
+                return Optional.of((HttpSession) trackableSession);
             }
         });
     }
 
     @Override
-    public Optional<String> getSessionId(WebContext context, boolean createSession) {
-        HttpSession session = getHttpSession(context);
-        return (session != null) ? Optional.of(session.getId()) : Optional.empty();
+    public Optional<String> getSessionId(final WebContext context, final boolean createSession) {
+        return getNativeSession(context, createSession).map(HttpSession::getId);
     }
 }


### PR DESCRIPTION
As discussed on [`pac4j-dev`](https://groups.google.com/g/pac4j-dev/c/t0va23k50Zk), this PR updates the `ServletSessionStore` to pass a `createSession` parameter to the "native" `getSession` function. This mimics the implementation of other session stores, and should also prevent an `IllegalStateException` from being thrown (originally addressed in https://github.com/pac4j/jax-rs-pac4j/commit/c0b55af92236c7b4c28322eb40bc63094af35407).

In addition to passing `createSession`, I also

- renamed `getHttpSession` to `getNativeSession` to align naming with the `JEESessionStore`
- used additional `Optional` syntax ([`map`](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#map-java.util.function.Function-), [`filter`](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#filter-java.util.function.Predicate-), ...) instead of conditionals
- removed the protected `httpSession` and its constructor, because `buildFromTrackableSession` creates a store with that session inline already

If those changes seem too much, I can undo those of course.

Once this PR is in, I'll create a backport PR targeting the `5.0.x` branch.
